### PR TITLE
Minor typo and propsed more precise name with Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ### Hunspell-TH: A Thai Dictionary Extension
 
-## Affix File For Thai Language, ภาษาไทย (Thailand) Dictionary
+## Affix File For the Central Thai Language, ภาษาไทย (Thailand) Dictionary
 
 [![Codename](https://img.shields.io/badge/Codename-Hunspell--TH-black.svg?longCache=true)](https://academic.syafiqhadzir.com/en-MY/research/) [![Version](https://img.shields.io/badge/Version-0.1e-yellowgreen.svg?longCache=true)](https://github.com/SyafiqHadzir/hunspell-th/tree/master/Release) [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg?longCache=true)](https://www.gnu.org/licenses/gpl-3.0) [![Status Experimental](https://img.shields.io/badge/Status-Experimental-black.svg?longCache=true)](https://github.com/SyafiqHadzir/hunspell-th/releases) ![Unicode ISO-8859-1](https://img.shields.io/badge/Unicode-UTF--8-green.svg?longCache=true) ![Unicode UTF-8](https://img.shields.io/badge/Wordlist-39792%20words-green.svg?longCache=true)
 


### PR DESCRIPTION
* Grammar: missing 'the' article
* Thai -> Central Thai: Why? This is a bit of an English semantics argument, but I believe Central Thai, ภาษาไทยกลาง,  is more precise than the more colloquial "Thai". In the dictionary files I did not see any Isaan or Northern or Southern (et. al.) words. Those languages are "Thai" and they come from the same language family and under the same country, but the lack of such words says to me that it's more precise to call this a Central Thai dictionary. I'm unsure if these semantics are bothered with in Thai (ภาษาไทยกลาง is ภาษาไทย?). There are a couple of notes on the [Wikipedia page](https://en.wikipedia.org/wiki/Thai_language) that point to this precision avoiding confusion amongst linguists and more broadly.